### PR TITLE
Fixed screenflow.pause test

### DIFF
--- a/testplan.org
+++ b/testplan.org
@@ -1358,7 +1358,7 @@ Press start button to begin.
 ** DONE Pause Menu
 #+name: screenflow.pause
 #+begin_src
-> ! p
+> p
 . . . . . . . . . . #  0
 . . . . . . . . . . #  1
 . . . . . . . . . . #  2


### PR DESCRIPTION
This test would work if the game started in the title screen, but then
the earlier doc tests would fail, so I removed the first exclamation
point.
