### PR TITLE
test runner enhancements

### DIFF
--- a/testris.py
+++ b/testris.py
@@ -26,13 +26,12 @@ Once testris is able to launch your program, this message
 will be replaced with instructions for implementing your
 first feature.
 """
-from __future__ import print_function # let's keep it 3.x compatible
 import sys, os, errno, subprocess, difflib, pprint, time, traceback
 import extract
 
 if sys.version_info.major < 3:
-    class FileNotFoundError(IOError):
-        pass
+    println("Sorry, testris requires Python 3.x.")
+    sys.exit(1)
 
 class Test(object):
     def __init__(self):

--- a/testris.py
+++ b/testris.py
@@ -79,6 +79,7 @@ def parse_test(lines):
 def spawn(program_args, use_shell):
     return subprocess.Popen(program_args,
                             shell=use_shell,
+                            universal_newlines=True,
                             stdin=subprocess.PIPE,
                             stdout=subprocess.PIPE)
 
@@ -98,48 +99,50 @@ def await_results(program, timeout_seconds=2):
         raise TimeoutFailure("<program timed out>")
 
 
-def run_test(program, opcodes):
-    # send all the input lines:
-    print(opcodes['title'])
-    print("---- sending commands ----")
+def send_cmds(program, opcodes):
     for cmd in opcodes['in']:
-        print(cmd)
-        program.stdin.write((cmd + "\n").encode('utf-8'))
-        # in python3, subprocess opens stdin in binary mode: http://hg.python.org/cpython/file/c9cb931b20f4/Lib/subprocess.py#l828
-        # with a default bufsize, which for binary mode is io.DEFAULT_BUFFER_SIZE (4096): https://docs.python.org/3.3/library/functions.html#open
-        # we can't use line buffering because, even though the subprocess docs don't say so
-        # and no error is thrown when you try, line buffering is only for text mode
-        # so, instead, we flush
+        program.stdin.write(cmd + "\n")
         program.stdin.flush()
 
-    # let the program do its thing:
-    print("---- awaiting results ----")
-    await_results(program)
-
-    # read all the actual output lines and compare to expected:
-    actual = [line.strip() for line in
-              program.stdout.read().decode('utf-8').split("\n")]
+def run_test(program, opcodes):
+    send_cmds(program, opcodes)
+    # send all the input lines:
+    (actual, errs) = program.communicate(timeout=2)
+    actual = [line.strip() for line in actual.splitlines()]
     while actual and actual[-1] == "":
         actual.pop()
     if actual != opcodes['out']:
+        print()
+        print("test [%s] failed" % opcodes['title'])
+        print("---- input ----")
+        for cmd in opcodes['in']:
+            print(cmd)
         print('\n'.join(opcodes['doc']))
-        print("---- expected results ----")
-        print('\n'.join(opcodes['out']))
+        #print("---- expected results ----")
+        #print('\n'.join(opcodes['out']))
+        print("---- diff from expected ----")
         diff = '\n'.join(list(difflib.Differ().compare(actual, opcodes['out'])))
-        raise TestFailure('output mismatch:\n' + diff)
+        print(diff)
+        raise TestFailure('output mismatch')
 
 def run_tests(program_args, use_shell):
-    for i, test in enumerate(extract.tests()):
-        program = spawn(program_args, use_shell)
-        opcodes = parse_test(test.lines)
-        print("Running test %d: %s" % (i+1, test.name))
-        try:
+    num_passed = 0
+    try:
+        for i, test in enumerate(extract.tests()):
+            opcodes = parse_test(test.lines)
+            program = spawn(program_args, use_shell)
             run_test(program, opcodes)
-            print("Test %d passed" % (i+1))
-        except (TimeoutFailure, TestFailure) as e:
-            print("Test %d failed: %s" % (i+1, e))
-            break
-        print("\n") # add 2 blank lines between tests
+            # either it passed or threw exception
+            print('.', end='')
+            num_passed += 1
+        else:
+            print()
+            print("All %d tests passed." % num_passed)
+    except (TimeoutFailure, TestFailure) as e:
+        print()
+        print("%d tests passed." % num_passed)
+        print("Test %d [%s] failed." % (i+1, test.name))
+
 
 def find_learntris():
     default = "./learntris"


### PR DESCRIPTION
- migrate runner to python3. (and update communication protocal to use `universal_newlines` and `.communicate`)
- Update test formatting:
  -  replace test numbers with test name (#29)
  -  suppress output for passing tests (#55)
-  add environment variables to control communication:
   - use `INPUT_PATH` to write commands to a separate file (rather than child's stdin)
   - use `SKIP_LINES=n` to ignore `n` lines of output (because Godot 4.2.1 wouldn't let me suppress the godot version number without turning off output completely)